### PR TITLE
Replace attribute indexer with setAttribute

### DIFF
--- a/internationalization.js
+++ b/internationalization.js
@@ -2,6 +2,6 @@
 for (const node of document.querySelectorAll('[data-i18n]')) {
   let [text, attr] = node.dataset.i18n.split('|');
   text = chrome.i18n.getMessage(text);
-  attr ? node[attr] = text : node.appendChild(document.createTextNode(text));
+  attr ? node.setAttribute(attr, text) : node.appendChild(document.createTextNode(text));
 }
 // ----------------- /Internationalization -----------------


### PR DESCRIPTION
Using element[attribute] = value doesn't work as expected for custom attributes. Using element.setAttribute(attribute, value) allows for custom attributes.